### PR TITLE
Add Continue extension to code-server

### DIFF
--- a/coderbot-v2/DOCKER_README.md
+++ b/coderbot-v2/DOCKER_README.md
@@ -124,9 +124,16 @@ docker-compose exec frontend sh
                     ┌─────────────────┐
                     │  Code Server    │
                     │     (IDE)       │
-                    │   Port: 8080    │
-                    └─────────────────┘
+│   Port: 8080    │
+└─────────────────┘
 ```
+
+### Extensões no Code Server
+
+O container `code-server` é construído com a extensão **Continue** já instalada.
+Isso permite utilizar a IDE com o assistente de IA assim que o serviço é iniciado.
+Caso queira adicionar outras extensões, edite `docker/Dockerfile.code-server` e
+reconstrua o serviço.
 
 ## 📁 Estrutura de Volumes
 

--- a/coderbot-v2/docker-compose.yml
+++ b/coderbot-v2/docker-compose.yml
@@ -76,13 +76,16 @@ services:
 
   # Code Server IDE (opcional)
   code-server:
-    image: codercom/code-server:latest
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.code-server
     container_name: coderbot-code-server
     ports:
       - "8787:8787"
     volumes:
       - ./:/home/coder/project
       - code_server_data:/home/coder/.local/share/code-server
+      - ./docker/code-server-config.yaml:/home/coder/.config/code-server/config.yaml:ro
     networks:
       - coderbot-network
     restart: unless-stopped

--- a/coderbot-v2/docker/Dockerfile.code-server
+++ b/coderbot-v2/docker/Dockerfile.code-server
@@ -1,0 +1,6 @@
+FROM codercom/code-server:latest
+
+# Install Continue extension
+RUN code-server --install-extension Continue.continue
+
+# Use the default entrypoint and command from the base image

--- a/coderbot-v2/docker/code-server-config.yaml
+++ b/coderbot-v2/docker/code-server-config.yaml
@@ -1,0 +1,2 @@
+extensions:
+  - Continue.continue


### PR DESCRIPTION
## Summary
- build `code-server` from a new Dockerfile
- auto-install the Continue extension
- mount a config with the extension
- document the new behaviour in Docker setup guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846e79a55f08323a099a861319b4c81