### PR TITLE
feat: add light mode support with global theme toggle

### DIFF
--- a/coderbot-v2/frontend/src/App.tsx
+++ b/coderbot-v2/frontend/src/App.tsx
@@ -32,8 +32,6 @@ const queryClient = new QueryClient();
 
 const App = () => {
   useEffect(() => {
-    document.documentElement.classList.add('dark');
-
     const posthogKey = import.meta.env.VITE_PUBLIC_POSTHOG_KEY || import.meta.env.VITE_POSTHOG_KEY;
     const posthogHost = import.meta.env.VITE_PUBLIC_POSTHOG_HOST || import.meta.env.VITE_POSTHOG_HOST || "https://us.i.posthog.com";
 

--- a/coderbot-v2/frontend/src/components/ThemeToggle.tsx
+++ b/coderbot-v2/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@/components/ui/button";
+import { useTheme } from "@/context/ThemeContext";
+import { cn } from "@/lib/utils";
+import { Moon, Sun } from "lucide-react";
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === "dark";
+  const label = isDark ? "Ativar modo claro" : "Ativar modo escuro";
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="icon"
+      onClick={toggleTheme}
+      aria-label={label}
+      className={cn(
+        "relative h-9 w-9 rounded-full border border-slate-200 bg-white shadow-sm transition-all hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:hover:border-slate-600 dark:hover:bg-slate-800",
+        className
+      )}
+    >
+      <Sun
+        className={cn(
+          "h-4 w-4 transition-all duration-200",
+          isDark ? "scale-0 rotate-90 opacity-0" : "scale-100 rotate-0 opacity-100"
+        )}
+      />
+      <Moon
+        className={cn(
+          "absolute h-4 w-4 transition-all duration-200",
+          isDark ? "scale-100 rotate-0 opacity-100" : "scale-0 -rotate-90 opacity-0"
+        )}
+      />
+      <span className="sr-only">{label}</span>
+    </Button>
+  );
+}

--- a/coderbot-v2/frontend/src/components/layout/AppSidebar.tsx
+++ b/coderbot-v2/frontend/src/components/layout/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { User, MessageSquare, Code, GraduationCap, Presentation, Mail, BookOpen } from "lucide-react";
+import { User, MessageSquare, GraduationCap, Presentation, BookOpen } from "lucide-react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
   Sidebar,
@@ -15,6 +15,8 @@ import {
 } from "@/components/ui/sidebar";
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { getCurrentUser } from "@/integrations/pocketbase/client";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { useTheme } from "@/context/ThemeContext";
 
 type NavItem = {
   id: string;
@@ -36,6 +38,7 @@ export const AppSidebar = ({ currentNav, onNavChange }: AppSidebarProps) => {
   const [userRole, setUserRole] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const { state } = useSidebar();
+  const { theme } = useTheme();
 
   // Memoizar busca do usuário para evitar recálculos
   useEffect(() => {
@@ -174,7 +177,16 @@ export const AppSidebar = ({ currentNav, onNavChange }: AppSidebarProps) => {
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
-      <SidebarFooter>
+      <SidebarFooter className="gap-3">
+        <div className="flex items-center justify-between gap-3 rounded-xl border border-sidebar-border bg-white/80 px-3 py-2 text-xs text-slate-600 shadow-sm dark:bg-sidebar/30 dark:text-sidebar-foreground">
+          <div className="flex flex-col">
+            <span className="font-semibold">Tema</span>
+            <span className="text-[0.65rem] text-slate-500 dark:text-sidebar-foreground dark:opacity-70">
+              {theme === "dark" ? "Modo escuro" : "Modo claro"}
+            </span>
+          </div>
+          <ThemeToggle />
+        </div>
         <SidebarTrigger />
       </SidebarFooter>
     </Sidebar>

--- a/coderbot-v2/frontend/src/context/ThemeContext.tsx
+++ b/coderbot-v2/frontend/src/context/ThemeContext.tsx
@@ -1,0 +1,94 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+type Theme = "light" | "dark";
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = "coderbot:theme";
+
+const getPreferredTheme = (): { theme: Theme; hasStoredPreference: boolean } => {
+  if (typeof window === "undefined") {
+    return { theme: "light", hasStoredPreference: false };
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === "light" || stored === "dark") {
+    return { theme: stored, hasStoredPreference: true };
+  }
+
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  return { theme: prefersDark ? "dark" : "light", hasStoredPreference: false };
+};
+
+export const ThemeProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [{ theme, hasStoredPreference }, setThemeState] = useState(() => getPreferredTheme());
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const root = document.documentElement;
+    root.classList.toggle("dark", theme === "dark");
+    root.classList.toggle("light", theme === "light");
+    root.dataset.theme = theme;
+    root.style.colorScheme = theme;
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (hasStoredPreference) {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [theme, hasStoredPreference]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || hasStoredPreference) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = (event: MediaQueryListEvent) => {
+      setThemeState({ theme: event.matches ? "dark" : "light", hasStoredPreference: false });
+    };
+
+    mediaQuery.addEventListener("change", handler);
+    return () => mediaQuery.removeEventListener("change", handler);
+  }, [hasStoredPreference]);
+
+  const setTheme = (nextTheme: Theme) => {
+    setThemeState({ theme: nextTheme, hasStoredPreference: true });
+  };
+
+  const toggleTheme = () => setTheme(theme === "dark" ? "light" : "dark");
+
+  const value = useMemo(
+    () => ({
+      theme,
+      setTheme,
+      toggleTheme,
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+};

--- a/coderbot-v2/frontend/src/home/Home.tsx
+++ b/coderbot-v2/frontend/src/home/Home.tsx
@@ -1,6 +1,7 @@
 // Home.tsx – Modern, impactful landing focused on conversion
 import * as React from "react";
 import { Button } from "@/components/ui/button";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import {
   ArrowRight,
   PlayCircle,
@@ -27,12 +28,12 @@ function Background() {
   return (
     <div aria-hidden className="absolute inset-0 -z-10 overflow-hidden">
       {/* Gradient backdrop (more purple, like the reference) */}
-      <div className="absolute inset-0 bg-gradient-to-br from-[#0e0a1f] via-[#161132] to-[#1f0e3a] dark:from-[#0e0a1f] dark:via-[#161132] dark:to-[#1f0e3a]" />
+      <div className="absolute inset-0 bg-gradient-to-br from-indigo-100 via-white to-white dark:from-[#0e0a1f] dark:via-[#161132] dark:to-[#1f0e3a]" />
       {/* Radial spotlights */}
-      <div className="absolute left-[60%] top-[-10%] h-[60rem] w-[60rem] -translate-x-1/2 rounded-full bg-fuchsia-500/20 blur-3xl dark:bg-fuchsia-500/20" />
-      <div className="absolute left-[-10%] top-[-20%] h-[40rem] w-[40rem] rounded-full bg-violet-600/20 blur-3xl" />
+      <div className="absolute left-[60%] top-[-10%] h-[60rem] w-[60rem] -translate-x-1/2 rounded-full bg-fuchsia-200/40 blur-3xl dark:bg-fuchsia-500/20" />
+      <div className="absolute left-[-10%] top-[-20%] h-[40rem] w-[40rem] rounded-full bg-violet-200/40 blur-3xl dark:bg-violet-600/20" />
       {/* Subtle grid overlay (reactbits-style) */}
-      <div className="pointer-events-none absolute inset-0 opacity-[0.08]
+      <div className="pointer-events-none absolute inset-0 opacity-[0.05]
                     [mask-image:radial-gradient(ellipse_at_center,black,transparent_70%)]
                     bg-[linear-gradient(0deg,transparent_24%,rgba(0,0,0,.35)_25%,rgba(0,0,0,.35)_26%,transparent_27%,transparent_74%,rgba(0,0,0,.35)_75%,rgba(0,0,0,.35)_76%,transparent_77%),linear-gradient(90deg,transparent_24%,rgba(0,0,0,.35)_25%,rgba(0,0,0,.35)_26%,transparent_27%,transparent_74%,rgba(0,0,0,.35)_75%,rgba(0,0,0,.35)_76%,transparent_77%)]
                     bg-[length:38px_38px] dark:opacity-[0.12]" />
@@ -641,10 +642,13 @@ export default function Home() {
           <img src="/coderbot_colorfull.png" alt="CoderBot" className="h-7 w-7" />
           <span className="text-sm font-semibold tracking-tight text-slate-800 dark:text-white">CoderBot</span>
         </a>
-        <div className="hidden gap-2 sm:flex">
-          <a href="/about" className="text-sm text-slate-600 hover:text-slate-900 dark:text-white/70 dark:hover:text-white">Sobre</a>
-          <a href="/auth" className="text-sm text-slate-600 hover:text-slate-900 dark:text-white/70 dark:hover:text-white">Entrar</a>
-          <a href="/dashboard" className="text-sm text-slate-600 hover:text-slate-900 dark:text-white/70 dark:hover:text-white">Dashboard</a>
+        <div className="flex items-center gap-2">
+          <nav className="hidden gap-2 sm:flex">
+            <a href="/about" className="text-sm text-slate-600 hover:text-slate-900 dark:text-white/70 dark:hover:text-white">Sobre</a>
+            <a href="/auth" className="text-sm text-slate-600 hover:text-slate-900 dark:text-white/70 dark:hover:text-white">Entrar</a>
+            <a href="/dashboard" className="text-sm text-slate-600 hover:text-slate-900 dark:text-white/70 dark:hover:text-white">Dashboard</a>
+          </nav>
+          <ThemeToggle />
         </div>
       </div>
 
@@ -655,14 +659,14 @@ export default function Home() {
         <div className="group flex flex-col items-start">
           
 
-          <h1 className="mt-5 max-w-[16ch] text-[clamp(2rem,7vw,3.75rem)] font-extrabold leading-[1.15] tracking-tight text-white [text-wrap:balance] sm:leading-[1.1]">
+          <h1 className="mt-5 max-w-[16ch] text-[clamp(2rem,7vw,3.75rem)] font-extrabold leading-[1.15] tracking-tight text-slate-900 [text-wrap:balance] sm:leading-[1.1] dark:text-white">
             Aprenda programação com IA —
             <span className="bg-gradient-to-r from-violet-400 to-fuchsia-500 bg-clip-text text-transparent drop-shadow-sm transition-colors duration-300"> rápido</span>
             <span> e </span>
             <span className="bg-gradient-to-r from-violet-400 to-fuchsia-500 bg-clip-text text-transparent drop-shadow-sm transition-colors duration-300">divertido.</span>
           </h1>
 
-          <p className="mt-5 max-w-[62ch] text-[clamp(1rem,2.3vw,1.125rem)] leading-relaxed text-white/80 [text-wrap:pretty]">
+          <p className="mt-5 max-w-[62ch] text-[clamp(1rem,2.3vw,1.125rem)] leading-relaxed text-slate-700 [text-wrap:pretty] dark:text-white/80">
             Trilhas personalizadas, exercícios práticos e insights de aprendizagem. Tudo o que você precisa para evoluir com consistência.
           </p>
 
@@ -670,7 +674,7 @@ export default function Home() {
             <Button
               asChild
               size="lg"
-              className="group gap-2 w-full sm:w-auto bg-gradient-to-r from-violet-500 to-fuchsia-600 text-white shadow-lg hover:from-violet-500/90 hover:to-fuchsia-600/90 border-0 focus-visible:ring-4 focus-visible:ring-violet-500/50 motion-reduce:transition-none"
+              className="group w-full gap-2 border-0 bg-gradient-to-r from-violet-500 to-fuchsia-600 text-white shadow-lg hover:from-violet-500/90 hover:to-fuchsia-600/90 focus-visible:ring-4 focus-visible:ring-violet-500/50 motion-reduce:transition-none sm:w-auto"
             >
               <a href="/auth" aria-label="Começar de graça, criar conta e iniciar" className="inline-flex items-center">
                 Começar de graça <ArrowRight className="h-4 w-4 -translate-y-px transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
@@ -680,7 +684,7 @@ export default function Home() {
               asChild
               variant="secondary"
               size="lg"
-              className="group gap-2 bg-white/10 text-white hover:bg-white/15 focus-visible:ring-4 focus-visible:ring-white/40 motion-reduce:transition-none"
+              className="group gap-2 border border-slate-200 bg-white/90 text-slate-700 shadow-sm hover:bg-slate-50 focus-visible:ring-4 focus-visible:ring-indigo-200/60 dark:border-white/20 dark:bg-white/10 dark:text-white dark:hover:bg-white/15 dark:focus-visible:ring-white/30"
             >
               <a href="/dashboard" aria-label="Ver demonstração do dashboard" className="inline-flex items-center">
                 <PlayCircle className="h-4 w-4" aria-hidden="true" /> Ver demo

--- a/coderbot-v2/frontend/src/main.tsx
+++ b/coderbot-v2/frontend/src/main.tsx
@@ -2,5 +2,10 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 import './components/coderbot/app/i18n.ts';
+import { ThemeProvider } from "@/context/ThemeContext";
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
+);

--- a/coderbot-v2/frontend/src/pages/Auth.tsx
+++ b/coderbot-v2/frontend/src/pages/Auth.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { startGithubOAuth } from "@/integrations/pocketbase/client";
 import AuthForm from "@/components/auth/AuthForm";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 export default function Auth() {
   const [isLoading, setIsLoading] = useState(false);
@@ -19,6 +20,9 @@ export default function Auth() {
       aria-busy={isLoading}
       className="relative isolate min-h-screen overflow-hidden bg-gradient-to-b from-indigo-50 to-white text-slate-900 dark:from-slate-950 dark:to-slate-950 dark:text-white"
     >
+      <div className="pointer-events-none absolute right-4 top-4 sm:right-6 sm:top-6">
+        <ThemeToggle className="pointer-events-auto" />
+      </div>
       {/* Global loading overlay */}
       {isLoading && (
         <div


### PR DESCRIPTION
## Summary
- add a global ThemeProvider that syncs the document theme with system preference and local storage
- create a reusable ThemeToggle button and surface it in the dashboard sidebar, home header and auth screen
- refresh the landing hero background and secondary CTA styles for a bright light mode experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d08623ac3c8323bc11e99d12401386