### PR TITLE
debug: add detailed logging for run_response in AgnoMethodologyService

### DIFF
--- a/coderbot-v2/backend/app/services/agno_methodology_service.py
+++ b/coderbot-v2/backend/app/services/agno_methodology_service.py
@@ -433,6 +433,16 @@ class AgnoMethodologyService:
             agent = self.get_agent(methodology)
             run_response = agent.run(prompt)
             
+            # DEBUG: Investigar estrutura do run_response
+            self.logger.info(f"🔍 DEBUG: run_response type = {type(run_response)}")
+            self.logger.info(f"🔍 DEBUG: run_response has content = {hasattr(run_response, 'content')}")
+            self.logger.info(f"🔍 DEBUG: run_response has messages = {hasattr(run_response, 'messages')}")
+            if hasattr(run_response, 'content'):
+                self.logger.info(f"🔍 DEBUG: run_response.content type = {type(run_response.content)}")
+                self.logger.info(f"🔍 DEBUG: run_response.content = {repr(run_response.content)[:200]}")
+            if hasattr(run_response, 'messages'):
+                self.logger.info(f"🔍 DEBUG: run_response.messages length = {len(run_response.messages)}")
+            
             # Extrair conteúdo da resposta de maneira robusta
             if hasattr(run_response, 'content'):
                 response = run_response.content


### PR DESCRIPTION
- Introduced debug logging to inspect the structure and content of the run_response object.
- Enhanced visibility into the response handling process by logging the type and attributes of run_response.
- Aimed at improving debugging capabilities and understanding of response formats during development.