### PR TITLE
fix: adjust padding in NotesPage container for improved layout

### DIFF
--- a/coderbot-v2/frontend/src/pages/NotesPage.tsx
+++ b/coderbot-v2/frontend/src/pages/NotesPage.tsx
@@ -199,7 +199,7 @@ export default function NotesPage() {
   if (isLoading) {
     return (
       <div className="h-full bg-background">
-        <div className="container mx-auto px-4 py-8">
+        <div className="container mx-auto px-4 py-8 pb-16">
           <div className="flex items-center justify-between mb-8">
             <div className="flex items-center gap-3">
               <BookOpen className="h-8 w-8 text-primary" />


### PR DESCRIPTION
- Increased bottom padding in the NotesPage container to enhance visual spacing and layout consistency.
- Aimed at providing a better user experience by ensuring content is not cramped at the bottom of the page.